### PR TITLE
Configure the server address via CARGO_VIBE_ADDR

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,8 @@ cargo vibe build
 
 # Configuration
 
+## Vibe Pattern
+
 By default, `cargo-vibe` will, on success, vibe full strength for 3 seconds.
 
 You can change that by setting `CARGO_VIBE_PATTERN` environment variable. For
@@ -24,6 +26,14 @@ CARGO_VIBE_PATTERN="0.2 1.5s" cargo vibe <cmd>
 You can also set full patterns of vibes to run, by separating them with slashes
 `/`. Here is one example:
 
-```
+```shell
 CARGO_VIBE_PATTERN="0.4 1s/0.6 1s/0.8 0.75s/1.0 0.25s"
+```
+
+## Server Address
+
+If your server is running at an address or port other than the default (`ws://127.0.0.1:1234`), you can override it using `CARGO_VIBE_ADDR`. For example:
+
+```shell
+CARGO_VIBE_ADDR="ws://172.31.160.1:69696"
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,8 +18,9 @@ const CLIENT_NAME: &str = "cargo-vibe";
 
 async fn connect_to_server() -> Result<ButtplugClient, ButtplugClientError> {
     let client = ButtplugClient::new(CLIENT_NAME);
+    let address = std::env::var("CARGO_VIBE_ADDR").unwrap_or(String::from("ws://127.0.0.1:1234"));
     let connector = RemoteConn::<_, JsonSer, _, _>::new(
-        WebSocketTransport::new_insecure_connector("ws://127.0.0.1:12345"),
+        WebSocketTransport::new_insecure_connector(address.as_str()),
     );
     client.connect(connector).await?;
     client.start_scanning().await?;


### PR DESCRIPTION
Add a new environment variable, CARGO_VIBE_ADDR, for overriding the default server address used by cargo-vibe.